### PR TITLE
fix(footer): fix the bad link to github repo

### DIFF
--- a/src/Components/Modules/Footer.tsx
+++ b/src/Components/Modules/Footer.tsx
@@ -118,7 +118,7 @@ const Footer: React.FC = () => {
             </Grid>
             <Grid item className={classes.item}>
               <a
-                href="https://github.com/web3/web3js"
+                href="https://github.com/web3/web3.js"
                 rel="noopener noreferrer"
                 target="_blank"
               >


### PR DESCRIPTION
There is an invalid link in the footer section pointing to `https://github.com/web3/web3js`, which should be `https://github.com/web3/web3.js`.