### PR TITLE
fix: remove non-existant language

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -63,8 +63,7 @@ const theme = createTheme({
 })
 
 const availableLanguages = [
-  { id: "en", label: "English" },
-  { id: "fr", label: "Français" }
+  { id: "en", label: "English" }
 ]
 
 const App: React.FC<{}> = () => {


### PR DESCRIPTION
Remove non-existant language. This breaks the website loading for users with french as first locale.