### PR TITLE
adding Ethereum Attestation Service(EAS) Plugin to the list

### DIFF
--- a/src/pluginList.ts
+++ b/src/pluginList.ts
@@ -40,23 +40,27 @@ export default [
     isFeatured: false
   },
   {
-    name : "web3-plugin-0x",
-    isFeatured : false
+    name: "web3-plugin-0x",
+    isFeatured: false
   },
   {
-    name : "@swisstronik/web3-plugin-swisstronik",
-    isFeatured : false
+    name: "@swisstronik/web3-plugin-swisstronik",
+    isFeatured: false
   },
   {
-    name : "@chainsafe/web3-plugin-eip4337",
-    isFeatured : true
+    name: "@chainsafe/web3-plugin-eip4337",
+    isFeatured: true
   },
   {
-    name : "web3-plugin-zksync",
-    isFeatured : true
+    name: "web3-plugin-zksync",
+    isFeatured: true
   },
-    {
-    name : "@namespace-ens/web3-plugin-ens",
-    isFeatured : false
+  {
+    name: "@namespace-ens/web3-plugin-ens",
+    isFeatured: false
+  },
+  {
+    name: "web3-plugin-eas",
+    isFeatured: false
   }
 ] as { name: string; isFeatured: boolean }[];


### PR DESCRIPTION
## Ethereum Attestation Service(EAS) Web3 Plugin

The Ethereum Attestation Service(EAS) Web3.js Plugin extends the capabilities of the Web3.js library to interact seamlessly with the [Ethereum Attestation Service](https://attest.sh/). This plugin provides convenient methods for interacting with the Ethereum Attestation Service(EAS) contracts.